### PR TITLE
Add command to make single request and display timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,40 @@ One of either `--delay` or `--freq` is required. If both are provided, delay wil
 - `lode test -d 1h -n 24 http://www.google.com` make 1 req/hr to Google until 24 requests have been made
 - `lode test -f 40 -c 8 -l 1m -n 1000 http://www.google.copm` make 40 req/sec to Google, split across 8 threads, for up to 1 minutes or until 1000 requests have been made (whichever comes first) 
 
+### `lode time [flags] [path]`
+Used to run a single request.
+A breakdown of the request's timing is printed at the end.
+
+**Supported flags:**
+| Flag | Shorthand | Usage |
+| --- | --- | --- |
+| `--timeout` | `-t` | Timeout per request, e.g. 200ms or 1s - defaults to 5s |
+| `--method` | `-m` | HTTP method to use - defaults to GET |
+
+**Example:**
+
+`lode time http://www.google.com` make 1 request to Google and print timings
+
+**Example output:**
+```
+❯ lode time https://www.google.com/
+Target: GET https://www.google.com/
+Concurrency: 1
+Requests made: 1
+Time taken: 290ms
+Requests per second (avg): 3.36
+
+Timing breakdown:
+<=>             DNS Lookup:        24ms
+   <=>          TCP Connection:    21ms
+      <=>       TLS Handshake:     184ms
+         <=>    Server:            66ms
+            <=> Response Transfer: 0s
+<=============> Total:             296ms
+```
+
 ### `lode workflow [flags] [path]` (not yet implemented)
 Used to run a sequence of load tests, as defined in the YAML file at the specified path.
-
-### `lode time [flags] [path]` (not yet implemented)
-Used to run a single request, and print the timings of each stage of the request.
-
 
 **Expected YAML format:**
 ```

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -47,6 +47,8 @@ e.g. lode test --freq 20 https://example.com`,
 		}
 		client := &http.Client{Timeout: timeout}
 		lode := lode.New(args[0], method, delay, client, concurrency, maxRequests, maxTime)
+
+		defer lode.Report()
 		lode.Run()
 	},
 }

--- a/cmd/time.go
+++ b/cmd/time.go
@@ -1,0 +1,53 @@
+/*
+Copyright © 2022 James Balazs <j.c.balazs1@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"github.com/JamesBalazs/lode/internal/lode"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// timeCmd represents the time command
+var timeCmd = &cobra.Command{
+	Use:   "time",
+	Short: "Make a single request",
+	Long: `Sends a single request and prints a handy timing breakdown.
+
+e.g. lode time --timeout 3s -m GET https://example.com`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := &http.Client{Timeout: timeout}
+		lode := lode.New(args[0], method, time.Duration(1), client, 1, 1, 0)
+
+		defer lode.Report()
+		lode.Run()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(timeCmd)
+
+	timeCmd.Flags().DurationVarP(&timeout, "timeout", "t", 5*time.Second, "Timeout per request, e.g. 200ms or 1s - defaults to 5s")
+	timeCmd.Flags().StringVarP(&method, "method", "m", "GET", "HTTP method to use - defaults to GET")
+}

--- a/internal/lode/lode_test.go
+++ b/internal/lode/lode_test.go
@@ -20,7 +20,16 @@ var client = &mocks.Client{}
 func TestNewReturnsLode(t *testing.T) {
 	assert := assert.New(t)
 	expectedRequest, _ := http.NewRequest(method, url, nil)
-	expectedLode := &Lode{delay, client, expectedRequest, 1, 1, 0, ResponseTimings(nil)}
+	expectedLode := &Lode{
+		TargetDelay:     delay,
+		Client:          client,
+		Request:         expectedRequest,
+		Concurrency:     1,
+		MaxRequests:     1,
+		MaxTime:         0,
+		StartTime:       time.Time{},
+		ResponseTimings: ResponseTimings(nil),
+	}
 
 	lode := New(url, method, delay, client, 1, 1, 0)
 
@@ -48,7 +57,7 @@ func TestRunDoesRequest(t *testing.T) {
 	response := &http.Response{}
 	clientMock.On("Do", mock.Anything).Return(response, nil)
 	logMock := new(mocks.Log)
-	logMock.On("Printf", mock.AnythingOfType("string")).Return() // report after requests TODO: find a more specific way to mock this
+	logMock.On("Printf", mock.AnythingOfType("string")).Return() // Report after requests TODO: find a more specific way to mock this
 	Logger = logMock
 
 	lode := New(url, method, delay, clientMock, 1, 1, 0)
@@ -63,7 +72,7 @@ func TestRunErrorDoingRequest(t *testing.T) {
 	clientMock.On("Do", mock.Anything).Return(&http.Response{}, errors.New("error doing request"))
 	logMock := new(mocks.Log)
 	logMock.On("Panicf", "Error during request: %s", "error doing request")
-	logMock.On("Printf", mock.AnythingOfType("string")).Return() // report after requests TODO: find a more specific way to mock this
+	logMock.On("Printf", mock.AnythingOfType("string")).Return() // Report after requests TODO: find a more specific way to mock this
 	Logger = logMock
 
 	lode := New(url, method, delay, clientMock, 1, 1, 0)

--- a/internal/lode/report/timing.go
+++ b/internal/lode/report/timing.go
@@ -2,9 +2,12 @@ package report
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http/httptrace"
 	"time"
 )
+
+const timingResolution = 1 * time.Millisecond
 
 type Timing struct {
 	DnsStart     time.Time
@@ -48,6 +51,21 @@ func (t *Timing) TotalDuration() time.Duration {
 	} else {
 		return t.Done.Sub(t.DnsStart)
 	}
+}
+
+func (t *Timing) String() string {
+	return fmt.Sprintf(`<=>             DNS Lookup:        %s
+   <=>          TCP Connection:    %s
+      <=>       TLS Handshake:     %s
+         <=>    Server:            %s
+            <=> Response Transfer: %s
+<=============> Total:             %s`,
+		t.DnsLookupDuration().Truncate(timingResolution),
+		t.TcpConnectDuration().Truncate(timingResolution),
+		t.TlsHandshakeDuration().Truncate(timingResolution),
+		t.ServerDuration().Truncate(timingResolution),
+		t.ResponseTransferDuration().Truncate(timingResolution),
+		t.TotalDuration().Truncate(timingResolution))
 }
 
 func NewTrace(timing *Timing) *httptrace.ClientTrace {

--- a/internal/lode/report/timing_test.go
+++ b/internal/lode/report/timing_test.go
@@ -9,47 +9,56 @@ import (
 )
 
 var timing = Timing{
-	DnsStart:     time.Unix(0, 1),
-	DnsDone:      time.Unix(0, 3),
-	ConnectStart: time.Unix(0, 7),
-	ConnectDone:  time.Unix(0, 13),
-	TlsStart:     time.Unix(0, 21),
-	TlsDone:      time.Unix(0, 31),
-	GotConn:      time.Unix(0, 33),
-	FirstByte:    time.Unix(0, 47),
-	Done:         time.Unix(0, 63),
+	DnsStart:     time.Unix(0, 1_000_000),
+	DnsDone:      time.Unix(0, 3_000_000),
+	ConnectStart: time.Unix(0, 7_000_000),
+	ConnectDone:  time.Unix(0, 13_000_000),
+	TlsStart:     time.Unix(0, 21_000_000),
+	TlsDone:      time.Unix(0, 31_000_000),
+	GotConn:      time.Unix(0, 33_000_000),
+	FirstByte:    time.Unix(0, 47_000_000),
+	Done:         time.Unix(0, 63_000_000),
 }
 
 func TestTiming_DnsLookupDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(2), timing.DnsLookupDuration())
+	assert.Equal(t, 2*time.Millisecond, timing.DnsLookupDuration())
 }
 
 func TestTiming_TcpConnectDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(10), timing.TcpConnectDuration())
+	assert.Equal(t, 10*time.Millisecond, timing.TcpConnectDuration())
 
 	withoutDnsLookup := timing
 	withoutDnsLookup.DnsDone = time.Time{} // did not do DNS lookup
-	assert.Equal(t, time.Duration(6), withoutDnsLookup.TcpConnectDuration())
+	assert.Equal(t, 6*time.Millisecond, withoutDnsLookup.TcpConnectDuration())
 }
 
 func TestTiming_TlsHandshakeDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(10), timing.TlsHandshakeDuration())
+	assert.Equal(t, 10*time.Millisecond, timing.TlsHandshakeDuration())
 }
 
 func TestTiming_ServerDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(14), timing.ServerDuration())
+	assert.Equal(t, 14*time.Millisecond, timing.ServerDuration())
 }
 
 func TestTiming_ResponseTransferDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(16), timing.ResponseTransferDuration())
+	assert.Equal(t, 16*time.Millisecond, timing.ResponseTransferDuration())
 }
 
 func TestTiming_TotalDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(62), timing.TotalDuration())
+	assert.Equal(t, 62*time.Millisecond, timing.TotalDuration())
 
 	withoutDnsLookup := timing
 	withoutDnsLookup.DnsDone = time.Time{} // did not do DNS lookup
-	assert.Equal(t, time.Duration(56), withoutDnsLookup.TotalDuration())
+	assert.Equal(t, 56*time.Millisecond, withoutDnsLookup.TotalDuration())
+}
+
+func TestTiming_String(t *testing.T) {
+	assert.Equal(t, `<=>             DNS Lookup:        2ms
+   <=>          TCP Connection:    10ms
+      <=>       TLS Handshake:     10ms
+         <=>    Server:            14ms
+            <=> Response Transfer: 16ms
+<=============> Total:             62ms`, timing.String())
 }
 
 func TestNewTrace(t *testing.T) {


### PR DESCRIPTION
Implements #9 - command to make a single request and display a fancy list of timings for DNS lookup, TLS handshake etc.