### PR TITLE
Add header flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ A summary report is printed at the end.
 | `--timeout` | `-t` | Timeout per request, e.g. 200ms or 1s - defaults to 5s |
 | `--body` | `-b` | POST/PUT body |
 | `--file` | `-F` | POST/PUT body filepath |
-
-
+| `--header` | `-H` | Request headers, in the form X-SomeHeader=value - separate headers with commas, or repeat the flag to add multiple headers |
 
 One of either `--delay` or `--freq` is required. If both are provided, delay will be calculated from the given frequency.
 
@@ -72,6 +71,7 @@ A breakdown of the request's timing is printed at the end.
 | `--timeout` | `-t` | Timeout per request, e.g. 200ms or 1s - defaults to 5s |
 | `--body` | `-b` | POST/PUT body |
 | `--file` | `-F` | POST/PUT body filepath |
+| `--header` | `-H` | Request headers, in the form X-SomeHeader=value - separate headers with commas, or repeat the flag to add multiple headers |
 
 **Example:**
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -32,6 +32,7 @@ import (
 var method, body, file string
 var freq, concurrency, maxRequests int
 var delay, timeout, maxTime time.Duration
+var headers []string
 
 // testCmd represents the test command
 var testCmd = &cobra.Command{
@@ -49,7 +50,7 @@ e.g. lode test --freq 20 https://example.com`,
 
 		body := files.ReaderFromFileOrString(file, body)
 		client := &http.Client{Timeout: timeout}
-		lode := lode.New(args[0], method, delay, client, concurrency, maxRequests, maxTime, body)
+		lode := lode.New(args[0], method, delay, client, concurrency, maxRequests, maxTime, body, headers)
 		defer lode.Report()
 		lode.Run()
 	},
@@ -68,4 +69,5 @@ func init() {
 	testCmd.Flags().DurationVarP(&timeout, "timeout", "t", 5*time.Second, "Timeout per request, e.g. 200ms or 1s - defaults to 5s")
 	testCmd.Flags().StringVarP(&body, "body", "b", "", "POST/PUT body")
 	testCmd.Flags().StringVarP(&file, "file", "F", "", "POST/PUT body filepath")
+	testCmd.Flags().StringSliceVarP(&headers, "header", "H", []string{}, "Request headers, in the form X-SomeHeader=value - separate headers with commas, or repeat the flag to add multiple headers")
 }

--- a/cmd/time.go
+++ b/cmd/time.go
@@ -40,7 +40,7 @@ e.g. lode time --timeout 3s -m GET https://example.com`,
 	Run: func(cmd *cobra.Command, args []string) {
 		body := files.ReaderFromFileOrString(file, body)
 		client := &http.Client{Timeout: timeout}
-		lode := lode.New(args[0], method, time.Duration(1), client, 1, 1, 0, body)
+		lode := lode.New(args[0], method, time.Duration(1), client, 1, 1, 0, body, headers)
 
 		defer lode.Report()
 		lode.Run()
@@ -54,5 +54,5 @@ func init() {
 	timeCmd.Flags().DurationVarP(&timeout, "timeout", "t", 5*time.Second, "Timeout per request, e.g. 200ms or 1s - defaults to 5s")
 	timeCmd.Flags().StringVarP(&body, "body", "b", "", "POST/PUT body")
 	timeCmd.Flags().StringVarP(&file, "file", "F", "", "POST/PUT body filepath")
-
+	timeCmd.Flags().StringSliceVarP(&headers, "header", "H", []string{}, "Request headers, in the form X-SomeHeader=value - separate headers with commas, or repeat the flag to add multiple headers")
 }

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -7,13 +7,18 @@ import (
 	"strings"
 )
 
+var open = func(name string) (reader io.Reader) {
+	var err error
+	reader, err = os.Open(name)
+	if err != nil {
+		log.Panicf("Error reading from file: %s", err.Error())
+	}
+	return
+}
+
 func ReaderFromFileOrString(file string, body string) (reader io.Reader) {
 	if len(file) > 0 {
-		var err error
-		reader, err = os.Open(file)
-		if err != nil {
-			log.Panicf("Error reading body from file: %s", err.Error())
-		}
+		reader = open(file)
 	} else {
 		reader = strings.NewReader(body)
 	}

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -1,0 +1,30 @@
+package files
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReaderFromFileOrString(t *testing.T) {
+	assert := assert.New(t)
+	oldOpen := open
+	expectedReader := strings.NewReader("Some body from file")
+	open = func(name string) io.Reader {
+		return expectedReader
+	}
+
+	reader := ReaderFromFileOrString("some/file/path", "")
+
+	assert.Equal(expectedReader, reader)
+
+	expectedBody := "Some body from string"
+	expectedReader = strings.NewReader(expectedBody)
+
+	reader = ReaderFromFileOrString("", expectedBody)
+
+	assert.Equal(expectedReader, reader)
+
+	open = oldOpen
+}

--- a/internal/lode/lode.go
+++ b/internal/lode/lode.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptrace"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -28,11 +29,16 @@ type Lode struct {
 	ResponseTimings ResponseTimings
 }
 
-func New(url string, method string, delay time.Duration, client HttpClientInt, concurrency int, maxRequests int, maxTime time.Duration, body io.Reader) *Lode {
+func New(url string, method string, delay time.Duration, client HttpClientInt, concurrency int, maxRequests int, maxTime time.Duration, body io.Reader, headers []string) *Lode {
 	req, err := NewRequest(method, url, body)
 	if err != nil {
 		Logger.Panicf("Error creating request: %s", err.Error())
 		return nil
+	}
+
+	for _, headerString := range headers {
+		headerParts := strings.SplitN(headerString, "=", 2)
+		req.Header[headerParts[0]] = []string{headerParts[1]}
 	}
 
 	return &Lode{


### PR DESCRIPTION
Implements #2 - setting headers via flag/flags

Example syntax:
`lode test --header Content-Type=application/json,X-Custom=value --header X-Custom-2=another`...