### PR TITLE
Change non-modifying functions to use value receiver

### DIFF
--- a/internal/lode/lode.go
+++ b/internal/lode/lode.go
@@ -80,7 +80,7 @@ func (l *Lode) Run() {
 	}
 }
 
-func (l *Lode) work(trigger <-chan time.Time, stop chan struct{}, result chan ResponseTiming) {
+func (l Lode) work(trigger <-chan time.Time, stop chan struct{}, result chan ResponseTiming) {
 	ctx := context.Background()
 	for {
 		select {
@@ -100,12 +100,12 @@ func (l *Lode) work(trigger <-chan time.Time, stop chan struct{}, result chan Re
 	}
 }
 
-func (l *Lode) stop(ticker *time.Ticker, stop chan struct{}) {
+func (l Lode) stop(ticker *time.Ticker, stop chan struct{}) {
 	ticker.Stop()
 	close(stop)
 }
 
-func (l *Lode) Report() {
+func (l Lode) Report() {
 	duration := time.Since(l.StartTime)
 	responseCount := len(l.ResponseTimings)
 	histogram := report.BuildStatusHistogram(l.ResponseTimings.Responses(), responseCount)
@@ -131,7 +131,7 @@ func (l *Lode) Report() {
 	Logger.Printf(output)
 }
 
-func (l *Lode) closeOnSigterm(channel chan ResponseTiming) {
+func (l Lode) closeOnSigterm(channel chan ResponseTiming) {
 	sigterm := make(chan os.Signal)
 	signal.Notify(sigterm, os.Interrupt, syscall.SIGTERM)
 	go func() {

--- a/internal/lode/report/report.go
+++ b/internal/lode/report/report.go
@@ -32,7 +32,7 @@ func (s *StatusHistogram) Add(statusCode int) {
 	s.Data[statusCode]++
 }
 
-func (s *StatusHistogram) String() (string string) {
+func (s StatusHistogram) String() (string string) {
 	sort.Ints(s.keys)
 	for _, statusCode := range s.keys {
 		statusCount := s.Data[statusCode]
@@ -63,7 +63,7 @@ func BuildLatencyPercentiles(timings []Timing) (histogram LatencyPercentiles) {
 	return
 }
 
-func (t *LatencyPercentiles) String() (string string) {
+func (t LatencyPercentiles) String() (string string) {
 	sort.Float64s(latencyPercentiles)
 	for _, percentile := range latencyPercentiles {
 		string = string + fmt.Sprintf("%dth: %dms\n", int(percentile), t.Data[int(percentile)])

--- a/internal/lode/report/timing.go
+++ b/internal/lode/report/timing.go
@@ -21,11 +21,11 @@ type Timing struct {
 	Done         time.Time
 }
 
-func (t *Timing) DnsLookupDuration() time.Duration {
+func (t Timing) DnsLookupDuration() time.Duration {
 	return t.DnsDone.Sub(t.DnsStart)
 }
 
-func (t *Timing) TcpConnectDuration() time.Duration {
+func (t Timing) TcpConnectDuration() time.Duration {
 	if t.DnsDone.IsZero() { // did not do DNS lookup (connecting to IP)
 		return t.ConnectDone.Sub(t.ConnectStart)
 	} else {
@@ -33,19 +33,19 @@ func (t *Timing) TcpConnectDuration() time.Duration {
 	}
 }
 
-func (t *Timing) TlsHandshakeDuration() time.Duration {
+func (t Timing) TlsHandshakeDuration() time.Duration {
 	return t.TlsDone.Sub(t.TlsStart)
 }
 
-func (t *Timing) ServerDuration() time.Duration {
+func (t Timing) ServerDuration() time.Duration {
 	return t.FirstByte.Sub(t.GotConn)
 }
 
-func (t *Timing) ResponseTransferDuration() time.Duration {
+func (t Timing) ResponseTransferDuration() time.Duration {
 	return t.Done.Sub(t.FirstByte)
 }
 
-func (t *Timing) TotalDuration() time.Duration {
+func (t Timing) TotalDuration() time.Duration {
 	var start time.Time
 
 	if !t.DnsStart.IsZero() {
@@ -63,7 +63,7 @@ func (t *Timing) TotalDuration() time.Duration {
 	return t.Done.Sub(start)
 }
 
-func (t *Timing) String() string {
+func (t Timing) String() string {
 	return fmt.Sprintf(`<=>             DNS Lookup:        %s
    <=>          TCP Connection:    %s
       <=>       TLS Handshake:     %s


### PR DESCRIPTION
Fixes #22 

This will slightly increase memory usage due to creating copies of structs on function calls. 

However, it should be safer for methods that _shouldn't_ ever mutate the receiver - especially wrt the `Lode` object which will have multiple copies of `work` running in Goroutines (and struct size shouldn't be an issue in that case, as `work` is only called when `ResponseTimings` is empty).