### PR TITLE
Exit code support and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ A summary report is printed at the end.
 | `--file` | `-F` | POST/PUT body filepath |
 | `--header` | `-H` | Request headers, in the form X-SomeHeader=value - separate headers with commas, or repeat the flag to add multiple headers |
 | `--interactive` | `-i` | Use interactive mode, which presents a scrollable list of requests, and shows the timing, body, and headers, of the selected request |
+| `--fail-fast` |  | Abort the test immediately if a non-success status code is received |
+| `--ignore-failures` |  | Don't return non-zero exit code when non-success status codes are received |
 
 One of either `--delay` or `--freq` is required. If both are provided, delay will be calculated from the given frequency.
 
@@ -80,6 +82,7 @@ A breakdown of the request's timing is printed at the end.
 | `--file` | `-F` | POST/PUT body filepath |
 | `--header` | `-H` | Request headers, in the form X-SomeHeader=value - separate headers with commas, or repeat the flag to add multiple headers |
 | `--interactive` | `-i` | Use interactive mode, which shows the timing, body, and headers, of the request |
+| `--ignore-failures` |  | Don't return non-zero exit code when non-success status codes are received |
 
 **Example:**
 
@@ -142,6 +145,8 @@ tests:
 | `body` | POST/PUT body |
 | `file` | POST/PUT body filepath |
 | `header` | Array of request headers, in the form X-SomeHeader=value |
+| `failfast` | Boolean - Abort the test immediately if a non-success status code is received |
+| `ignorefailures` | Boolean - Don't return non-zero exit code when non-success status codes are received |
 
 ## Planned Features
 - Log responses to a file

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -42,6 +42,7 @@ e.g. lode test --freq 20 https://example.com`,
 		params.Url = args[0]
 		lode := lode.New(params)
 		lode.Interactive = interactive
+		defer lode.ExitWithCode()
 		defer lode.Report()
 		lode.Run()
 	},
@@ -62,5 +63,7 @@ func init() {
 	testCmd.Flags().StringVarP(&params.File, "file", "F", "", "POST/PUT body filepath")
 	testCmd.Flags().StringSliceVarP(&params.Headers, "header", "H", []string{}, "Request headers, in the form X-SomeHeader=value - separate headers with commas, or repeat the flag to add multiple headers")
 
+	testCmd.Flags().BoolVar(&params.FailFast, "fail-fast", false, "Abort the test immediately if a non-success status code is received")
+	testCmd.Flags().BoolVar(&params.IgnoreFailures, "ignore-failures", false, "Don't return non-zero exit code when non-success status codes are received")
 	testCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "Interactive list of responses and timing data")
 }

--- a/cmd/time.go
+++ b/cmd/time.go
@@ -43,6 +43,7 @@ e.g. lode time --timeout 3s -m GET https://example.com`,
 		params.MaxRequests = 1
 		lode := lode.New(params)
 		lode.Interactive = interactive
+		defer lode.ExitWithCode()
 		defer lode.Report()
 		lode.Run()
 	},
@@ -58,4 +59,5 @@ func init() {
 	timeCmd.Flags().StringSliceVarP(&params.Headers, "header", "H", []string{}, "Request headers, in the form X-SomeHeader=value - separate headers with commas, or repeat the flag to add multiple headers")
 
 	timeCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "Interactive list of responses and timing data")
+	timeCmd.Flags().BoolVar(&params.IgnoreFailures, "ignore-failures", false, "Don't return non-zero exit code when non-success status codes are received")
 }

--- a/internal/lode/mocks/lode.go
+++ b/internal/lode/mocks/lode.go
@@ -15,3 +15,7 @@ func (l *Lode) Run() {
 func (l *Lode) Report() {
 	l.Called()
 }
+
+func (l *Lode) ExitWithCode() {
+	l.Called()
+}

--- a/internal/lode/mocks/log.go
+++ b/internal/lode/mocks/log.go
@@ -28,3 +28,8 @@ func (l *Log) Panicf(str string, v ...interface{}) {
 	strings := append([]interface{}{str}, v...)
 	l.Called(strings...)
 }
+
+func (l *Log) Fatalf(str string, v ...interface{}) {
+	strings := append([]interface{}{str}, v...)
+	l.Called(strings...)
+}

--- a/internal/lode/params.go
+++ b/internal/lode/params.go
@@ -6,17 +6,19 @@ import (
 )
 
 type Params struct {
-	Url         string
-	Method      string
-	Body        string
-	File        string
-	Freq        int
-	Concurrency int
-	MaxRequests int
-	Delay       time.Duration
-	Timeout     time.Duration
-	MaxTime     time.Duration
-	Headers     []string
+	Url            string
+	Method         string
+	Body           string
+	File           string
+	Freq           int
+	Concurrency    int
+	MaxRequests    int
+	Delay          time.Duration
+	Timeout        time.Duration
+	MaxTime        time.Duration
+	Headers        []string
+	FailFast       bool
+	IgnoreFailures bool
 }
 
 func (p Params) Validate() {

--- a/internal/lode/suite.go
+++ b/internal/lode/suite.go
@@ -32,4 +32,7 @@ func (s *Suite) Run() {
 		lode.Run()
 		lode.Report()
 	}
+	for _, lode := range s.lodes {
+		lode.ExitWithCode()
+	}
 }

--- a/internal/lode/suite_test.go
+++ b/internal/lode/suite_test.go
@@ -50,10 +50,12 @@ func TestSuite_Run(t *testing.T) {
 			lode2,
 		},
 	}
-	lode1.On("Run").Return().Once()
-	lode1.On("Report").Return().Once()
-	lode2.On("Run").Return().Once()
-	lode2.On("Report").Return().Once()
+	lode1.On("Run").Once()
+	lode1.On("Report").Once()
+	lode2.On("Run").Once()
+	lode2.On("Report").Once()
+	lode1.On("ExitWithCode").Once()
+	lode2.On("ExitWithCode").Once()
 
 	suite.Run()
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -9,6 +9,7 @@ import (
 type LodeInt interface {
 	Run()
 	Report()
+	ExitWithCode()
 }
 
 type HttpClientInt interface {
@@ -20,6 +21,7 @@ type LoggerInt interface {
 	Printf(string, ...interface{})
 	Panicln(...interface{})
 	Panicf(string, ...interface{})
+	Fatalf(string, ...interface{})
 }
 
 type TemplateInt interface {


### PR DESCRIPTION
Closes #35 - exit with code `1` after the test, if non-success statuses are received during the test.
Adds flags:
- `--ignore-failures` to always exit with code `0` even if non-success statuses are received
- `--fail-fast` to abort test immediately when non-success status received