### PR TITLE
Add homebrew distribution to goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,12 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
+brews:
+- name: lode
+  homepage: https://github.com/JamesBalazs/homebrew-tools
+  tap:
+    owner: JamesBalazs
+    name: homebrew-tools
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Adds homebrew to Goreleaser config
Use PAT with access to homebrew-tools repo for Goreleaser, rather than the built-in Actions token

(I get a 404 from `curl` when installing with Homebrew to test this, but I'm assuming that's because the repo is private. The download works fine when I visit the link with an authenticated browser)