### PR TITLE
Switch coverage action to Goveralls

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,11 +55,6 @@ jobs:
       run: |
         go test -v -covermode=count -coverprofile=coverage.out ./...
 
-    - name: Convert coverage.out to coverage.lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.8
-
-    - name: Coveralls
-      uses: coverallsapp/github-action@1.1.3
+    - uses: shogo82148/actions-goveralls@v1
       with:
-        github-token: ${{ secrets.github_token }}
-        path-to-lcov: coverage.lcov
+        path-to-profile: coverage.out


### PR DESCRIPTION
Something in `setup-go@v3` breaks `jandelgado/gcov2lcov-action` so moving away from that and testing out [shogo82148/actions-goveralls](https://github.com/shogo82148/actions-goveralls) which seems to make it a bit easier to get coverage into Coveralls.