### PR TITLE
Move all actions to Go 1.19.x to fix release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 1.19.x
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.3.0
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.16.x
+        go-version: 1.19.x
 
     - name: Test
       run: go test -v -covermode=count ./...
@@ -49,7 +49,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.16.x
+        go-version: 1.19.x
 
     - name: Calc coverage
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.3.0
         with:
-          version: v1.29
+          version: latest
 
   test:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Goreleaser
+gname: Goreleaser
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 1.19.x
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3

--- a/internal/lode/lode.go
+++ b/internal/lode/lode.go
@@ -174,7 +174,7 @@ func (l *Lode) Report() {
 }
 
 func (l Lode) closeOnSigterm(channel chan responseTimings.ResponseTiming) {
-	sigterm := make(chan os.Signal)
+	sigterm := make(chan os.Signal, 1)
 	signal.Notify(sigterm, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sigterm


### PR DESCRIPTION
When goreleaser-action updated from v2 -> v3 they deprecated windows/arm64 builds on Go versions prior to 1.17 which broke the build a few minor versions ago

It _is_ an officially supported build target in 1.17+ and there's no reason this project won't build/run on 1.19+ so I've jumped to the latest version on my laptop + GitHub actions