### PR TITLE
Remove coveralls - no longer free for open source / blocked access

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,23 +38,3 @@ jobs:
 
     - name: Test
       run: go test -v -covermode=count ./...
-
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      if: success()
-
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.19.x
-
-    - name: Calc coverage
-      run: |
-        go test -v -covermode=count -coverprofile=coverage.out ./...
-
-    - uses: shogo82148/actions-goveralls@v1
-      with:
-        path-to-profile: coverage.out


### PR DESCRIPTION
This repo was "paused" by coveralls following their pricing change - apparently open source repos are no longer free by default? Removing coveralls as a result, will redo the coverage check at a later date without sending to a third party.